### PR TITLE
update postgres minor version

### DIFF
--- a/cloudformation/aqua-ecs-ec2/aquaEcs.yaml
+++ b/cloudformation/aqua-ecs-ec2/aquaEcs.yaml
@@ -932,7 +932,7 @@ Resources:
       DeleteAutomatedBackups: False
       DeletionProtection: False
       Engine: postgres
-      EngineVersion: 11.9
+      EngineVersion: 11.15
       MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretU, ':SecretString}}' ]]
       MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretP, ':SecretString}}' ]]
       MultiAZ: !Ref MultiAzDatabase
@@ -957,7 +957,7 @@ Resources:
       DeleteAutomatedBackups: False
       DeletionProtection: False
       Engine: postgres
-      EngineVersion: 11.9
+      EngineVersion: 11.15
       MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretU, ':SecretString}}' ]]
       MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretP, ':SecretString}}' ]]
       MultiAZ: !Ref MultiAzDatabase

--- a/cloudformation/aqua-ecs-fargate/AquaFargate-nonSSL.yaml
+++ b/cloudformation/aqua-ecs-fargate/AquaFargate-nonSSL.yaml
@@ -768,7 +768,7 @@ Resources:
       DeleteAutomatedBackups: False
       DeletionProtection: False
       Engine: postgres
-      EngineVersion: 11.9
+      EngineVersion: 11.15
       MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretU, ':SecretString}}' ]]
       MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretP, ':SecretString}}' ]]
       MultiAZ: !Ref MultiAzDatabase
@@ -793,7 +793,7 @@ Resources:
       DeleteAutomatedBackups: False
       DeletionProtection: False
       Engine: postgres
-      EngineVersion: 11.9
+      EngineVersion: 11.15
       MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretU, ':SecretString}}' ]]
       MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretP, ':SecretString}}' ]]
       MultiAZ: !Ref MultiAzDatabase

--- a/cloudformation/aqua-ecs-fargate/aquaFargate.yaml
+++ b/cloudformation/aqua-ecs-fargate/aquaFargate.yaml
@@ -778,7 +778,7 @@ Resources:
       DeleteAutomatedBackups: False
       DeletionProtection: False
       Engine: postgres
-      EngineVersion: 11.9
+      EngineVersion: 11.15
       MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretU, ':SecretString}}' ]]
       MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretP, ':SecretString}}' ]]
       MultiAZ: !Ref MultiAzDatabase
@@ -803,7 +803,7 @@ Resources:
       DeleteAutomatedBackups: False
       DeletionProtection: False
       Engine: postgres
-      EngineVersion: 11.9
+      EngineVersion: 11.15
       MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretU, ':SecretString}}' ]]
       MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretP, ':SecretString}}' ]]
       MultiAZ: !Ref MultiAzDatabase

--- a/cloudformation/aqua-ecs/aquaEcs.yaml
+++ b/cloudformation/aqua-ecs/aquaEcs.yaml
@@ -731,7 +731,7 @@ Resources:
       DBInstanceClass: !Ref RdsInstanceClass
       DBSubnetGroupName: !Ref RdsInstanceSubnetGroup
       Engine: postgres
-      EngineVersion: 9.6.9
+      EngineVersion: 11.15
       MasterUsername: !Ref RdsMasterUsername
       MasterUserPassword: !Ref RdsMasterPassword
       MultiAZ: !Ref MultiAzDatabase


### PR DESCRIPTION
Hello, guys, thank for good work.
I work for a company that verifies Aqua Enterprises.

The following error occurred when I creating stack.

```
Cannot find version 11.9 for postgres (Service: AmazonRDS; Status Code: 400; Error Code: InvalidParameterCombination; Request ID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX; Proxy: null)
```

I checked and it seems that it is currently supported from version 11.12 or later, as shown in the following article.

[Reported Amazon RDS PostgreSQL issue](https://aws.amazon.com/security/security-bulletins/AWS-2022-004/?nc1=h_ls)

In addition, the following is a list of currently supported versions of PostgreSQL in the AWS CLI.

```
[cloudshell-user@ip-10-0-27-103 ~]$ aws rds describe-db-engine-versions --engine postgres --query ‘DBEngineVersions[].EngineVersion’ --output table --region us-east-1
--------------------------
|DescribeDBEngineVersions|
+------------------------+
|  9.6.22                |
|  9.6.23                |
|  9.6.24                |
|  10.17                 |
|  10.18                 |
|  10.19                 |
|  10.20                 |
|  11.12                 |
|  11.13                 |
|  11.14                 |
|  11.15                 |
|  12.7                  |
|  12.8                  |
|  12.9                  |
|  12.10                 |
|  13.3                  |
|  13.4                  |
|  13.5                  |
|  13.6                  |
|  14.1                  |
|  14.2                  |
+------------------------+
```

I checked the Aqua Databse spec sheet below and 11.5 is within the scope of support.
Therefore, we are sending a pull request with 11.5, which is the recommended AWS version.

[System Requirements - Aqua Database](https://docs.aquasec.com/docs/system-requirements#section-aqua-database)

Other documents for reference are attached.

- [Choosing a major version upgrade for PostgreSQL](https://docs.amazonaws.cn/en_us/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion)
- [Amazon RDS for PostgreSQL updates](https://docs.amazonaws.cn/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-versions.html#postgresql-versions-version11)
