### PR TITLE
Changing Go Runtime Environment

### DIFF
--- a/cloudformation/aqua-lambda/aquaServerless.yaml
+++ b/cloudformation/aqua-lambda/aquaServerless.yaml
@@ -24,7 +24,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: auditlambda
-      Runtime: go1.x
+      Runtime: provided.al2023
       CodeUri:
         Bucket: !Ref S3Bucket
         Key:  !Ref S3CodeKey


### PR DESCRIPTION
Updating the Runtime value from go1.x to provided.al2023 as the old value is deprecated. It causes the CloudFormation deployment to fail.  Additional details can be found here - https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/